### PR TITLE
Dispatch the training loop on the mode type

### DIFF
--- a/src/ApplicationDrivenLearning.jl
+++ b/src/ApplicationDrivenLearning.jl
@@ -477,22 +477,36 @@ function train!(
     # constraint have to be in place before training starts
     _build(model)
 
-    y = Y
+    return _train!(options.mode, model, X, Y, options.params)
+end
 
-    if options.mode == NelderMeadMode
-        return _train_with_nelder_mead!(model, X, y, options.params)
-    elseif options.mode == GradientMode
-        return _train_with_gradient!(model, X, y, options.params)
-    elseif options.mode == NelderMeadMPIMode
-        return _train_with_nelder_mead_mpi!(model, X, y, options.params)
-    elseif options.mode == GradientMPIMode
-        return _train_with_gradient_mpi!(model, X, y, options.params)
-    elseif options.mode == BilevelMode
-        return _solve_bilevel(model, X, y, options.params)
-    else
-        # should never get here: Options rejects unknown modes on construction
-        throw(ArgumentError("Invalid optimization method"))
-    end
+"""
+    _train!(mode, model, X, Y, params)
+
+Run the training loop belonging to `mode`.
+
+One method per [`AbstractOptimizationMode`](@ref), defined next to the loop it
+calls rather than listed here, so that adding a mode is adding a method. This
+matters beyond tidiness: a mode implemented in a package extension can add a
+method, and cannot add a branch to an `if`.
+
+`Options` rejects unknown modes on construction, so the fallback below is only
+reachable by calling this directly - which is why it names the mode rather than
+saying that something was invalid.
+"""
+function _train!(
+    mode,
+    ::Model,
+    ::AbstractMatrix{<:Real},
+    ::AbstractMatrix{<:Real},
+    ::Dict{Symbol,Any},
+)
+    return throw(
+        ArgumentError(
+            "No training loop is defined for mode $mode. Every mode needs a " *
+            "`_train!(::Type{Mode}, model, X, Y, params)` method.",
+        ),
+    )
 end
 
 # train! with any other supported container: vectors, Tables.jl tables such as a

--- a/src/optimizers/bilevel.jl
+++ b/src/optimizers/bilevel.jl
@@ -221,3 +221,19 @@ function _solve_bilevel(
         extract_params(model.forecast),
     )
 end
+
+"""
+    _train!(::Type{BilevelMode}, model, X, Y, params)
+
+Dispatch entry point for [`BilevelMode`](@ref); see
+[`_solve_bilevel`](@ref).
+"""
+function _train!(
+    ::Type{BilevelMode},
+    model::Model,
+    X::AbstractMatrix{<:Real},
+    Y::AbstractMatrix{<:Real},
+    params::Dict{Symbol,Any},
+)
+    return _solve_bilevel(model, X, Y, params)
+end

--- a/src/optimizers/gradient.jl
+++ b/src/optimizers/gradient.jl
@@ -135,3 +135,19 @@ function _train_with_gradient!(
 
     return Solution(best_C, best_θ)
 end
+
+"""
+    _train!(::Type{GradientMode}, model, X, Y, params)
+
+Dispatch entry point for [`GradientMode`](@ref); see
+[`_train_with_gradient!`](@ref).
+"""
+function _train!(
+    ::Type{GradientMode},
+    model::Model,
+    X::AbstractMatrix{<:Real},
+    Y::AbstractMatrix{<:Real},
+    params::Dict{Symbol,Any},
+)
+    return _train_with_gradient!(model, X, Y, params)
+end

--- a/src/optimizers/gradient_mpi.jl
+++ b/src/optimizers/gradient_mpi.jl
@@ -174,3 +174,19 @@ function _train_with_gradient_mpi!(
 
     return Solution(best_C, best_θ)
 end
+
+"""
+    _train!(::Type{GradientMPIMode}, model, X, Y, params)
+
+Dispatch entry point for [`GradientMPIMode`](@ref); see
+[`_train_with_gradient_mpi!`](@ref).
+"""
+function _train!(
+    ::Type{GradientMPIMode},
+    model::Model,
+    X::AbstractMatrix{<:Real},
+    Y::AbstractMatrix{<:Real},
+    params::Dict{Symbol,Any},
+)
+    return _train_with_gradient_mpi!(model, X, Y, params)
+end

--- a/src/optimizers/nelder_mead.jl
+++ b/src/optimizers/nelder_mead.jl
@@ -47,3 +47,19 @@ function _train_with_nelder_mead!(
     final_cost = Optim.minimum(res)
     return Solution(final_cost, final_sol)
 end
+
+"""
+    _train!(::Type{NelderMeadMode}, model, X, Y, params)
+
+Dispatch entry point for [`NelderMeadMode`](@ref); see
+[`_train_with_nelder_mead!`](@ref).
+"""
+function _train!(
+    ::Type{NelderMeadMode},
+    model::Model,
+    X::AbstractMatrix{<:Real},
+    Y::AbstractMatrix{<:Real},
+    params::Dict{Symbol,Any},
+)
+    return _train_with_nelder_mead!(model, X, Y, params)
+end

--- a/src/optimizers/nelder_mead_mpi.jl
+++ b/src/optimizers/nelder_mead_mpi.jl
@@ -82,3 +82,19 @@ function _train_with_nelder_mead_mpi!(
 
     return Solution(final_cost, final_sol)
 end
+
+"""
+    _train!(::Type{NelderMeadMPIMode}, model, X, Y, params)
+
+Dispatch entry point for [`NelderMeadMPIMode`](@ref); see
+[`_train_with_nelder_mead_mpi!`](@ref).
+"""
+function _train!(
+    ::Type{NelderMeadMPIMode},
+    model::Model,
+    X::AbstractMatrix{<:Real},
+    Y::AbstractMatrix{<:Real},
+    params::Dict{Symbol,Any},
+)
+    return _train_with_nelder_mead_mpi!(model, X, Y, params)
+end


### PR DESCRIPTION
`train!` selected its loop with an `if/elseif` chain over the mode singletons,
which means the set of modes is closed: everything that can run has to be listed
in one function in the main module.

Replace it with `_train!(options.mode, model, X, Y, params)` and one
`_train!(::Type{Mode}, ...)` method next to each loop, so that adding a mode is
adding a method. That is not only tidier -- a mode implemented in a package
extension can add a method, and cannot add a branch to an `if`, so this is the
prerequisite for putting a solver backend behind a weak dependency.

Behaviour-preserving: every method delegates to the loop the chain called, and
`Options` still rejects unknown modes on construction. The fallback method is
therefore reachable only by calling `_train!` directly, which is why it names the
mode rather than reporting that something was invalid.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
